### PR TITLE
update config version to make it consistent with compile locally

### DIFF
--- a/mainnet.md
+++ b/mainnet.md
@@ -59,7 +59,7 @@ docker run \
   -v path/to/smartbchd_home:/root/.smartbchd \
   smartbchd:latest init mynode --chain-id 0x2710
 
-wget https://github.com/smartbch/artifacts/releases/download/v0.0.3/dot.smartbchd.tgz
+wget https://github.com/smartbch/artifacts/releases/download/v0.0.6/dot.smartbchd.tgz
 tar xvf dot.smartbchd.tgz
 cp -rfv dot.smartbchd/* smartbchd_home/
 ```

--- a/testnets.md
+++ b/testnets.md
@@ -88,7 +88,7 @@ cd smartbch
 docker image build -f Dockerfile.optimized \
 	--build-arg SMARTBCH_BUILD_TAGS='cppbtree,params_amber' \
 	--build-arg SMARTBCH_VERSION=v0.4.2 \
-	--build-arg CONFIG_VERSION=v0.0.4 \
+	--build-arg CONFIG_VERSION=v0.0.5 \
 	--build-arg CHAIN_ID=0x2711 \
 	-t smartbchd-amber:latest .
 ```
@@ -102,7 +102,7 @@ docker run \
   -v path/to/smartbchd_home:/root/.smartbchd \
   smartbchd:latest init mynode --chain-id 0x2711
 
-wget https://github.com/smartbch/artifacts/releases/download/v0.0.4/dot.smartbchd.tgz
+wget https://github.com/smartbch/artifacts/releases/download/v0.0.5/dot.smartbchd.tgz
 tar xvf dot.smartbchd.tgz
 cp -rfv dot.smartbchd/* smartbchd_home/
 ```


### PR DESCRIPTION
Update config version in docker instruction part to be consistent with compile locally instruction. (v0.0.6 for Mainnet and v0.0.5 for Amber testnet).